### PR TITLE
Set initial model type in algorithms

### DIFF
--- a/sample/algorithm/npp_window.py
+++ b/sample/algorithm/npp_window.py
@@ -158,6 +158,7 @@ def npp_window(
         unmap_fn=npp_unmapping,
         output_fn=output_fn,
         pipeline_args=pipeline_args,
+        initial_mtype="ising",
     )
 
     # Run the pipeline

--- a/sample/algorithm/npp_window.py
+++ b/sample/algorithm/npp_window.py
@@ -157,8 +157,8 @@ def npp_window(
         solve_fn=npp_solving,
         unmap_fn=npp_unmapping,
         output_fn=output_fn,
-        pipeline_args=pipeline_args,
         initial_mtype="ising",
+        pipeline_args=pipeline_args,
     )
 
     # Run the pipeline

--- a/sawatabi/algorithm/abstract_algorithm.py
+++ b/sawatabi/algorithm/abstract_algorithm.py
@@ -209,7 +209,9 @@ class AbstractAlgorithm(BaseMixin):
 
         solved = (algorithm_transformed
             | "Make windows to key-value pairs for stateful DoFn" >> beam.Map(lambda element: (None, element))
-            | "Solve" >> beam.ParDo(sawatabi.algorithm.Window.SolveDoFn(), algorithm=algorithm, map_fn=map_fn, unmap_fn=unmap_fn, solve_fn=solve_fn, initial_mtype=initial_mtype))
+            | "Solve" >> beam.ParDo(
+                sawatabi.algorithm.Window.SolveDoFn(), algorithm=algorithm, map_fn=map_fn, unmap_fn=unmap_fn, solve_fn=solve_fn, initial_mtype=initial_mtype
+            ))
 
         # --------------------------------
         # Output part

--- a/sawatabi/algorithm/abstract_algorithm.py
+++ b/sawatabi/algorithm/abstract_algorithm.py
@@ -55,6 +55,7 @@ class AbstractAlgorithm(BaseMixin):
             map_fn=None,
             unmap_fn=None,
             solve_fn=None,
+            initial_mtype=sawatabi.constants.MODEL_ISING,
         ):
             _, elements = value
 
@@ -78,7 +79,7 @@ class AbstractAlgorithm(BaseMixin):
             else:
                 prev_elements = elements_state_as_list[-1]
             if len(model_state_as_list) == 0:
-                prev_model = sawatabi.model.LogicalModel(mtype="ising")
+                prev_model = sawatabi.model.LogicalModel(mtype=initial_mtype)
             else:
                 prev_model = model_state_as_list[-1]
 
@@ -163,8 +164,14 @@ class AbstractAlgorithm(BaseMixin):
         solve_fn=None,
         unmap_fn=None,
         output_fn=None,
+        initial_mtype=sawatabi.constants.MODEL_ISING,
         pipeline_args=["--runner=DirectRunner"],
     ):
+        cls._check_argument_type(initial_mtype, str)
+        valid_initial_mtypes = [sawatabi.constants.MODEL_ISING, sawatabi.constants.MODEL_QUBO]
+        if initial_mtype not in valid_initial_mtypes:
+            raise ValueError(f"'initial_mtype' must be one of {valid_initial_mtypes}.")
+
         pipeline_options = PipelineOptions(pipeline_args)
         p = beam.Pipeline(options=pipeline_options)
 
@@ -202,7 +209,7 @@ class AbstractAlgorithm(BaseMixin):
 
         solved = (algorithm_transformed
             | "Make windows to key-value pairs for stateful DoFn" >> beam.Map(lambda element: (None, element))
-            | "Solve" >> beam.ParDo(sawatabi.algorithm.Window.SolveDoFn(), algorithm=algorithm, map_fn=map_fn, unmap_fn=unmap_fn, solve_fn=solve_fn))
+            | "Solve" >> beam.ParDo(sawatabi.algorithm.Window.SolveDoFn(), algorithm=algorithm, map_fn=map_fn, unmap_fn=unmap_fn, solve_fn=solve_fn, initial_mtype=initial_mtype))
 
         # --------------------------------
         # Output part

--- a/sawatabi/algorithm/delta.py
+++ b/sawatabi/algorithm/delta.py
@@ -20,9 +20,7 @@ from sawatabi.algorithm.abstract_algorithm import AbstractAlgorithm
 
 class Delta(AbstractAlgorithm):
     @classmethod
-    def create_pipeline(
-        cls, algorithm_options, input_fn=None, map_fn=None, solve_fn=None, unmap_fn=None, output_fn=None, pipeline_args=["--runner=DirectRunner"]
-    ):
+    def create_pipeline(cls, algorithm_options, **kwargs):
         algorithm_transform = (
             "Fixed windows" >> beam.WindowInto(beam.window.FixedWindows(size=algorithm_options["window.size"]))
             | "Add timestamp as tuple againt each window for diff detection" >> beam.ParDo(AbstractAlgorithm.WithTimestampTupleFn())
@@ -34,12 +32,7 @@ class Delta(AbstractAlgorithm):
             algorithm=sawatabi.constants.ALGORITHM_DELTA,
             algorithm_transform=algorithm_transform,
             algorithm_options=algorithm_options,
-            input_fn=input_fn,
-            map_fn=map_fn,
-            solve_fn=solve_fn,
-            unmap_fn=unmap_fn,
-            output_fn=output_fn,
-            pipeline_args=pipeline_args,
+            **kwargs,
         )
 
     ################################

--- a/sawatabi/algorithm/incremental.py
+++ b/sawatabi/algorithm/incremental.py
@@ -20,9 +20,7 @@ from sawatabi.algorithm.abstract_algorithm import AbstractAlgorithm
 
 class Incremental(AbstractAlgorithm):
     @classmethod
-    def create_pipeline(
-        cls, algorithm_options, input_fn=None, map_fn=None, solve_fn=None, unmap_fn=None, output_fn=None, pipeline_args=["--runner=DirectRunner"]
-    ):
+    def create_pipeline(cls, algorithm_options, **kwargs):
         algorithm_transform = (
             "Fixed windows for increment" >> beam.WindowInto(beam.window.FixedWindows(size=algorithm_options["incremental.size"]))
             | "Add timestamp as tuple againt each window for diff detection" >> beam.ParDo(AbstractAlgorithm.WithTimestampTupleFn())
@@ -34,12 +32,7 @@ class Incremental(AbstractAlgorithm):
             algorithm=sawatabi.constants.ALGORITHM_INCREMENTAL,
             algorithm_transform=algorithm_transform,
             algorithm_options=algorithm_options,
-            input_fn=input_fn,
-            map_fn=map_fn,
-            solve_fn=solve_fn,
-            unmap_fn=unmap_fn,
-            output_fn=output_fn,
-            pipeline_args=pipeline_args,
+            **kwargs,
         )
 
     ################################

--- a/sawatabi/algorithm/window.py
+++ b/sawatabi/algorithm/window.py
@@ -20,9 +20,7 @@ from sawatabi.algorithm.abstract_algorithm import AbstractAlgorithm
 
 class Window(AbstractAlgorithm):
     @classmethod
-    def create_pipeline(
-        cls, algorithm_options, input_fn=None, map_fn=None, solve_fn=None, unmap_fn=None, output_fn=None, pipeline_args=["--runner=DirectRunner"]
-    ):
+    def create_pipeline(cls, algorithm_options, **kwargs):
         algorithm_transform = (
             "Sliding windows" >> beam.WindowInto(beam.window.SlidingWindows(size=algorithm_options["window.size"], period=algorithm_options["window.period"]))
             | "Add timestamp as tuple againt each window for diff detection" >> beam.ParDo(AbstractAlgorithm.WithTimestampTupleFn())
@@ -34,12 +32,7 @@ class Window(AbstractAlgorithm):
             algorithm=sawatabi.constants.ALGORITHM_WINDOW,
             algorithm_transform=algorithm_transform,
             algorithm_options=algorithm_options,
-            input_fn=input_fn,
-            map_fn=map_fn,
-            solve_fn=solve_fn,
-            unmap_fn=unmap_fn,
-            output_fn=output_fn,
-            pipeline_args=pipeline_args,
+            **kwargs,
         )
 
     ################################

--- a/tests/algorithm/test_window.py
+++ b/tests/algorithm/test_window.py
@@ -100,6 +100,39 @@ def test_window_algorithm_npp_10():
     os.remove(f"{output_path}-00000-of-00001")
 
 
+def test_window_algorithm_npp_invalid_mtype():
+    output_path = "tests/algorithm/output.txt"
+
+    algorithm_options = {"window.size": 30, "window.period": 5, "output.with_timestamp": True, "input.reassign_timestamp": True}
+
+    pipeline_args = ["--runner=DirectRunner"]
+    # pipeline_args.append("--save_main_session")  # If save_main_session is true, pickle of the session fails on Windows unit tests
+
+    with pytest.raises(ValueError):
+        Window.create_pipeline(
+            algorithm_options=algorithm_options,
+            input_fn=IO.read_from_text_as_number(path="tests/algorithm/numbers_10.txt"),
+            map_fn=npp_window.npp_mapping,
+            solve_fn=npp_window.npp_solving,
+            unmap_fn=npp_window.npp_unmapping,
+            output_fn=IO.write_to_text(path=output_path),
+            initial_mtype="invalid",
+            pipeline_args=pipeline_args,
+        )
+
+    with pytest.raises(TypeError):
+        Window.create_pipeline(
+            algorithm_options=algorithm_options,
+            input_fn=IO.read_from_text_as_number(path="tests/algorithm/numbers_10.txt"),
+            map_fn=npp_window.npp_mapping,
+            solve_fn=npp_window.npp_solving,
+            unmap_fn=npp_window.npp_unmapping,
+            output_fn=IO.write_to_text(path=output_path),
+            initial_mtype=123,
+            pipeline_args=pipeline_args,
+        )
+
+
 def test_window_algorithm_npp_gcp_and_custom_fn(capfd):
     algorithm_options = {"window.size": 30, "window.period": 10, "input.reassign_timestamp": True}
 

--- a/tests/solver/test_local_solver.py
+++ b/tests/solver/test_local_solver.py
@@ -161,9 +161,9 @@ def test_local_solver_n_hot_ising(n, s):
         assert np.count_nonzero(result == 1) == n
         assert np.count_nonzero(result == -1) == s - n
 
-        # Execution time should be within seconds (5 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 5.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 5.0
+        # Execution time should be within practical seconds (10 sec).
+        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
+        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
 
 
 @pytest.mark.parametrize("n,s", [(1, 2), (1, 3), (2, 3), (1, 4), (2, 4), (1, 100), (10, 100)])
@@ -182,9 +182,9 @@ def test_local_solver_n_hot_qubo(n, s):
         assert np.count_nonzero(result == 1) == n
         assert np.count_nonzero(result == 0) == s - n
 
-        # Execution time should be within seconds (5 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 5.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 5.0
+        # Execution time should be within practical seconds (10 sec).
+        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
+        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
 
 
 @pytest.mark.parametrize("n,s,i", [(1, 4, 0), (1, 4, 1), (1, 4, 2), (1, 4, 3), (2, 10, 5)])
@@ -204,9 +204,9 @@ def test_local_solver_n_hot_ising_with_deleting(n, s, i):
         assert np.count_nonzero(result == 1) == n
         assert np.count_nonzero(result == -1) == s - n - 1
 
-        # Execution time should be within seconds (5 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 5.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 5.0
+        # Execution time should be within practical seconds (10 sec).
+        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
+        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
 
 
 @pytest.mark.parametrize("n,s,i,j", [(1, 4, 0, 1), (1, 4, 2, 3), (2, 10, 5, 8)])
@@ -227,9 +227,9 @@ def test_local_solver_n_hot_qubo_with_deleting(n, s, i, j):
         assert np.count_nonzero(result == 1) == n
         assert np.count_nonzero(result == 0) == s - n - 2
 
-        # Execution time should be within seconds (5 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 5.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 5.0
+        # Execution time should be within practical seconds (10 sec).
+        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
+        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
 
 
 ################################
@@ -254,9 +254,9 @@ def test_local_solver_equality_ising(m, n):
         result_2 = result[m : (m + n)]  # noqa: E203
         assert np.count_nonzero(result_1 == 1) == np.count_nonzero(result_2 == 1)
 
-        # Execution time should be within 5 sec.
-        assert resultset.info["timing"]["elapsed_sec"] <= 5.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 5.0
+        # Execution time should be within practical seconds (10 sec).
+        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
+        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
 
 
 @pytest.mark.parametrize("m,n", [(2, 2), (10, 10), (10, 20), (50, 50)])
@@ -276,9 +276,9 @@ def test_local_solver_equality_qubo(m, n):
         result_2 = result[m : (m + n)]  # noqa: E203
         assert np.count_nonzero(result_1 == 1) == np.count_nonzero(result_2 == 1)
 
-        # Execution time should be within 5 sec...
-        assert resultset.info["timing"]["elapsed_sec"] <= 5.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 5.0
+        # Execution time should be within practical seconds (10 sec).
+        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
+        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
 
 
 ################################
@@ -300,9 +300,9 @@ def test_local_solver_zero_or_one_hot_ising(n):
         result = np.array(resultset.record[0].sample)
         assert np.count_nonzero(result == 1) in [0, 1]
 
-        # Execution time should be within seconds (5 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 5.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 5.0
+        # Execution time should be within practical seconds (10 sec).
+        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
+        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
 
 
 @pytest.mark.parametrize("n", [2, 3, 4, 10, 100])
@@ -319,6 +319,6 @@ def test_local_solver_zero_or_one_hot_qubo(n):
         result = np.array(resultset.record[0].sample)
         assert np.count_nonzero(result == 1) in [0, 1]
 
-        # Execution time should be within seconds (5 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 5.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 5.0
+        # Execution time should be within practical seconds (10 sec).
+        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
+        assert resultset.info["timing"]["elapsed_counter"] <= 10.0

--- a/tests/solver/test_sawatabi_solver.py
+++ b/tests/solver/test_sawatabi_solver.py
@@ -74,9 +74,9 @@ def test_sawatabi_solver_n_hot_ising(n, s):
     assert np.count_nonzero(result == 1) == n
     assert np.count_nonzero(result == -1) == s - n
 
-    # Execution time should be within 5 sec.
-    assert resultset.info["timing"]["elapsed_sec"] <= 5.0
-    assert resultset.info["timing"]["elapsed_counter"] <= 5.0
+    # Execution time should be within practical seconds (10 sec).
+    assert resultset.info["timing"]["elapsed_sec"] <= 10.0
+    assert resultset.info["timing"]["elapsed_counter"] <= 10.0
 
 
 @pytest.mark.parametrize("n,s", [(1, 2), (1, 3), (2, 3), (1, 4), (2, 4), (1, 100), (10, 100)])
@@ -93,9 +93,9 @@ def test_sawatabi_solver_n_hot_qubo(n, s):
     assert np.count_nonzero(result == 1) == n
     assert np.count_nonzero(result == 0) == s - n
 
-    # Execution time should be within 5 sec...
-    assert resultset.info["timing"]["elapsed_sec"] <= 5.0
-    assert resultset.info["timing"]["elapsed_counter"] <= 5.0
+    # Execution time should be within practical seconds (10 sec).
+    assert resultset.info["timing"]["elapsed_sec"] <= 10.0
+    assert resultset.info["timing"]["elapsed_counter"] <= 10.0
 
 
 @pytest.mark.parametrize("n,s,i", [(1, 4, 0), (1, 4, 1), (1, 4, 2), (1, 4, 3), (2, 10, 5)])

--- a/tests/utils/test_profile.py
+++ b/tests/utils/test_profile.py
@@ -40,8 +40,8 @@ def _create_n_variable_random_complete_model(n=4, seed=None):
 def test_create_n_variable_random_complete_model(n):
     result = _create_n_variable_random_complete_model(n=n, seed=12345)
 
-    # execution time should be less than 5 sec
-    assert result["profile"]["elapsed_sec"] < 5.0
+    # Execution time should be within practical seconds (10 sec).
+    assert result["profile"]["elapsed_sec"] < 10.0
 
 
 @profile
@@ -66,5 +66,5 @@ def _create_nxn_random_lattice_model(n=4, seed=None):
 def test_create_nxn_random_lattice_model(n):
     result = _create_nxn_random_lattice_model(n=n, seed=12345)
 
-    # execution time should be less than 5 sec
-    assert result["profile"]["elapsed_sec"] < 5.0
+    # Execution time should be within practical seconds (10 sec).
+    assert result["profile"]["elapsed_sec"] < 10.0


### PR DESCRIPTION
## Bug description

Currently the type of an initial model created by the sawatabi algorithms is only limited to `ising`. We have to deal with `qubo` also.