### PR TITLE
Update tsp_window.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
             "seaborn>=0.11.0,<1.0.0",
         ],
         "trial": [
+            "geopy>=2.0.0,<3.0.0",
             "optuna>=2.4.0,<3.0.0",
             "python-Levenshtein>=0.12.0,<1.0.0",
         ],


### PR DESCRIPTION
`from_pyqubo` はsawatabiの `add_interaction` でインタラクションを追加する代わりの操作として用意しているので、

1. add_interactionでLogicalModelにインタラクションを追加していくか
2. from_pyquboでLogicalModelのインタラクションをpyqubo expressionから一括で設定するか

のどちらかを選ぶことになります。今回はpyquboで作りかけているので、2 でやることにして add_interactionの部分は消しちゃいました。

2 のpyquboから設定するアプローチでやっていくとすると、pyquboはmodelの差分更新に対応していないので（1 の代替手段なので）、prev_modelは無視して、curr_dataから都度新しいモデルを作成することになるのでそうしました。

あと、ライブラリの不備でPlaceholderの値を与える部分はアルゴリズム層からまだ与える仕組みができていなかったので直接数値を書いちゃってます。

あと、mapping, unmapping, solving 関数で発生した例外をsawatabi内でつぶしちゃってるからユーサーまで到達してなくてデバッグしにくくなってたことにも気づきました。ライブラリ側の改善ポイントということで...

## 実行結果

各ウィンドウごとに最適ルートの答えが出るようになっています。

```
% python sample/algorithm/tsp_window.py --input="tests/algorithm/cities_to_visit.json"                                                                                                                                                                                   (git)-[TSP-experiment-kotarot]

args: Namespace(dataflow=False, dataflow_bucket=None, input='tests/algorithm/cities_to_visit.json', input_subscription=None, input_topic=None, output=None, output_topic=None, project=None)

{'window.size': 5, 'window.period': 1, 'output.with_timestamp': True, 'output.prefix': '<<<\n', 'output.suffix': '\n>>>\n'}
<_ChainedPTransform(PTransform) label=[ReadFromText|To JSON]>
WARNING:apache_beam.transforms.core:Key coder FastPrimitivesCoder for transform <ParDo(PTransform) label=[Assign global index for Ising variables]> with stateful DoFn may not be deterministic. This may cause incorrect behavior for complex key types. Consider adding an input type hint for this transform.
WARNING:apache_beam.transforms.core:Key coder FastPrimitivesCoder for transform <ParDo(PTransform) label=[Solve]> with stateful DoFn may not be deterministic. This may cause incorrect behavior for complex key types. Consider adding an input type hint for this transform.
pipeline: <apache_beam.pipeline.Pipeline object at 0x14197ec70>
/Users/kotaro/Repo/sawatabi/sawatabi/model/logical_model.py:84: UserWarning: Variables name 'city' is not defined in the model, but will be created instead of appending it.
  warnings.warn(f"Variables name '{name}' is not defined in the model, but will be created instead of appending it.")
<<<
[1970-01-01 00:00:04.999000]
INPUT -->
  [{'Sapporo': [141.34694, 43.064170000000004]}, {'Sendai': [140.87194, 38.26889]}, {'Tokyo': [139.69167, 35.689440000000005]}, {'Yokohama': [139.6425, 35.44778]}, {'Nagoya': [136.90667, 35.180279999999996]}]
SOLUTION ==>
  Sapporo -> Sendai -> Tokyo -> Nagoya -> Yokohama
>>>

<<<
[1970-01-01 00:00:03.999000] The received event is outdated: Timestamp is 1970-01-01 00:00:03.999000, while an event with timestamp of 1970-01-01 00:00:03.999000 has been already processed.
>>>

<<<
[1970-01-01 00:00:02.999000] The received event is outdated: Timestamp is 1970-01-01 00:00:02.999000, while an event with timestamp of 1970-01-01 00:00:02.999000 has been already processed.
>>>

<<<
[1970-01-01 00:00:01.999000] The received event is outdated: Timestamp is 1970-01-01 00:00:01.999000, while an event with timestamp of 1970-01-01 00:00:01.999000 has been already processed.
>>>

<<<
[1970-01-01 00:00:00.999000] The received event is outdated: Timestamp is 1970-01-01 00:00:00.999000, while an event with timestamp of 1970-01-01 00:00:00.999000 has been already processed.
>>>

<<<
[1970-01-01 00:00:05.999000]
INPUT -->
  [{'Sendai': [140.87194, 38.26889]}, {'Tokyo': [139.69167, 35.689440000000005]}, {'Yokohama': [139.6425, 35.44778]}, {'Nagoya': [136.90667, 35.180279999999996]}, {'Kyoto': [135.75556, 35.021390000000004]}]
SOLUTION ==>
  Sendai -> Kyoto -> Nagoya -> Tokyo -> Yokohama
>>>

<<<
[1970-01-01 00:00:06.999000]
INPUT -->
  [{'Tokyo': [139.69167, 35.689440000000005]}, {'Yokohama': [139.6425, 35.44778]}, {'Nagoya': [136.90667, 35.180279999999996]}, {'Kyoto': [135.75556, 35.021390000000004]}, {'Osaka': [135.52, 34.68639]}]
SOLUTION ==>
  Tokyo -> Osaka -> Kyoto -> Yokohama -> Nagoya
>>>

<<<
[1970-01-01 00:00:07.999000]
INPUT -->
  [{'Yokohama': [139.6425, 35.44778]}, {'Nagoya': [136.90667, 35.180279999999996]}, {'Kyoto': [135.75556, 35.021390000000004]}, {'Osaka': [135.52, 34.68639]}, {'Hiroshima': [132.45944, 34.396390000000004]}]
SOLUTION ==>
  Nagoya -> Hiroshima -> Kyoto -> Osaka -> Yokohama
>>>

<<<
[1970-01-01 00:00:08.999000]
INPUT -->
  [{'Nagoya': [136.90667, 35.180279999999996]}, {'Kyoto': [135.75556, 35.021390000000004]}, {'Osaka': [135.52, 34.68639]}, {'Hiroshima': [132.45944, 34.396390000000004]}, {'Fukuoka': [130.41806, 33.606390000000005]}]
SOLUTION ==>
  Fukuoka -> Hiroshima -> Kyoto -> Nagoya -> Osaka
>>>

<<<
[1970-01-01 00:00:09.999000]
INPUT -->
  [{'Kyoto': [135.75556, 35.021390000000004]}, {'Osaka': [135.52, 34.68639]}, {'Hiroshima': [132.45944, 34.396390000000004]}, {'Fukuoka': [130.41806, 33.606390000000005]}, {'Naha': [127.68111, 26.2125]}]
SOLUTION ==>
  Fukuoka -> Kyoto -> Osaka -> Hiroshima -> Naha
>>>

<<<
[1970-01-01 00:00:10.999000]
INPUT -->
  [{'Osaka': [135.52, 34.68639]}, {'Hiroshima': [132.45944, 34.396390000000004]}, {'Fukuoka': [130.41806, 33.606390000000005]}, {'Naha': [127.68111, 26.2125]}]
SOLUTION ==>
  Naha -> Osaka -> Hiroshima -> Fukuoka
>>>

<<<
[1970-01-01 00:00:11.999000]
INPUT -->
  [{'Hiroshima': [132.45944, 34.396390000000004]}, {'Fukuoka': [130.41806, 33.606390000000005]}, {'Naha': [127.68111, 26.2125]}]
SOLUTION ==>
  Fukuoka -> Hiroshima -> Naha
>>>

<<<
[1970-01-01 00:00:12.999000]
INPUT -->
  [{'Fukuoka': [130.41806, 33.606390000000005]}, {'Naha': [127.68111, 26.2125]}]
SOLUTION ==>
  Fukuoka -> Naha
>>>

<<<
[1970-01-01 00:00:13.999000]
INPUT -->
  [{'Naha': [127.68111, 26.2125]}]
SOLUTION ==>
  Naha
>>>

result: DONE
```