### PR TITLE
Refactor solvers (DWaveSolver and LocalSolver)

### DIFF
--- a/sample/model/constraint/n_hot_from_scratch.py
+++ b/sample/model/constraint/n_hot_from_scratch.py
@@ -31,7 +31,7 @@ def _print_utf8(model):
         print(model)
 
 
-def n_hot_from_scratch_2_of_1_qubo():
+def n_hot_from_scratch_2_of_1_qubo(solver):
     print("\n=== N-hot from scratch (2 of 1) qubo ===")
     model = sawatabi.model.LogicalModel(mtype="qubo")
     x = model.variables("x", shape=(2,))
@@ -44,13 +44,11 @@ def n_hot_from_scratch_2_of_1_qubo():
     model.add_interaction(x[1], coefficient=-coeff)
     _print_utf8(model)
 
-    physical = model.to_physical()
-    solver = sawatabi.solver.LocalSolver(exact=True)
-    resultset = solver.solve(physical)
+    resultset = solver.solve(model.to_physical())
     print(resultset)
 
 
-def n_hot_from_scratch_3_of_1_qubo():
+def n_hot_from_scratch_3_of_1_qubo(solver):
     print("\n=== N-hot from scratch (3 of 1) qubo ===")
     model = sawatabi.model.LogicalModel(mtype="qubo")
     x = model.variables("x", shape=(3,))
@@ -66,13 +64,11 @@ def n_hot_from_scratch_3_of_1_qubo():
     model.add_interaction(x[2], coefficient=-coeff)
     _print_utf8(model)
 
-    physical = model.to_physical()
-    solver = sawatabi.solver.LocalSolver(exact=True)
-    resultset = solver.solve(physical)
+    resultset = solver.solve(model.to_physical())
     print(resultset)
 
 
-def n_hot_from_scratch_3_of_2_qubo():
+def n_hot_from_scratch_3_of_2_qubo(solver):
     print("\n=== N-hot from scratch (3 of 2) qubo ===")
     model = sawatabi.model.LogicalModel(mtype="qubo")
     x = model.variables("x", shape=(3,))
@@ -88,13 +84,11 @@ def n_hot_from_scratch_3_of_2_qubo():
     model.add_interaction(x[2], coefficient=-coeff)
     _print_utf8(model)
 
-    physical = model.to_physical()
-    solver = sawatabi.solver.LocalSolver(exact=True)
-    resultset = solver.solve(physical)
+    resultset = solver.solve(model.to_physical())
     print(resultset)
 
 
-def n_hot_from_scratch_4_of_1_qubo():
+def n_hot_from_scratch_4_of_1_qubo(solver):
     print("\n=== N-hot from scratch (4 of 1) qubo ===")
     model = sawatabi.model.LogicalModel(mtype="qubo")
     x = model.variables("x", shape=(4,))
@@ -114,13 +108,11 @@ def n_hot_from_scratch_4_of_1_qubo():
     model.add_interaction(x[3], coefficient=-coeff)
     _print_utf8(model)
 
-    physical = model.to_physical()
-    solver = sawatabi.solver.LocalSolver(exact=True)
-    resultset = solver.solve(physical)
+    resultset = solver.solve(model.to_physical())
     print(resultset)
 
 
-def n_hot_from_scratch_4_of_2_qubo():
+def n_hot_from_scratch_4_of_2_qubo(solver):
     print("\n=== N-hot from scratch (4 of 2) qubo ===")
     model = sawatabi.model.LogicalModel(mtype="qubo")
     x = model.variables("x", shape=(4,))
@@ -140,13 +132,11 @@ def n_hot_from_scratch_4_of_2_qubo():
     model.add_interaction(x[3], coefficient=-coeff)
     _print_utf8(model)
 
-    physical = model.to_physical()
-    solver = sawatabi.solver.LocalSolver(exact=True)
-    resultset = solver.solve(physical)
+    resultset = solver.solve(model.to_physical())
     print(resultset)
 
 
-def n_hot_from_scratch_2_of_1_ising():
+def n_hot_from_scratch_2_of_1_ising(solver):
     print("\n=== N-hot from scratch (2 of 1) ising ===")
     model = sawatabi.model.LogicalModel(mtype="ising")
     x = model.variables("x", shape=(2,))
@@ -159,13 +149,11 @@ def n_hot_from_scratch_2_of_1_ising():
     model.add_interaction(x[1], coefficient=-coeff)
     _print_utf8(model)
 
-    physical = model.to_physical()
-    solver = sawatabi.solver.LocalSolver(exact=True)
-    resultset = solver.solve(physical)
+    resultset = solver.solve(model.to_physical())
     print(resultset)
 
 
-def n_hot_from_scratch_3_of_1_ising():
+def n_hot_from_scratch_3_of_1_ising(solver):
     print("\n=== N-hot from scratch (3 of 1) ising ===")
     model = sawatabi.model.LogicalModel(mtype="ising")
     x = model.variables("x", shape=(3,))
@@ -181,13 +169,11 @@ def n_hot_from_scratch_3_of_1_ising():
     model.add_interaction(x[2], coefficient=-coeff)
     _print_utf8(model)
 
-    physical = model.to_physical()
-    solver = sawatabi.solver.LocalSolver(exact=True)
-    resultset = solver.solve(physical)
+    resultset = solver.solve(model.to_physical())
     print(resultset)
 
 
-def n_hot_from_scratch_3_of_2_ising():
+def n_hot_from_scratch_3_of_2_ising(solver):
     print("\n=== N-hot from scratch (3 of 2) ising ===")
     model = sawatabi.model.LogicalModel(mtype="ising")
     x = model.variables("x", shape=(3,))
@@ -203,13 +189,11 @@ def n_hot_from_scratch_3_of_2_ising():
     model.add_interaction(x[2], coefficient=-coeff)
     _print_utf8(model)
 
-    physical = model.to_physical()
-    solver = sawatabi.solver.LocalSolver(exact=True)
-    resultset = solver.solve(physical)
+    resultset = solver.solve(model.to_physical())
     print(resultset)
 
 
-def n_hot_from_scratch_4_of_1_ising():
+def n_hot_from_scratch_4_of_1_ising(solver):
     print("\n=== N-hot from scratch (4 of 1) ising ===")
     model = sawatabi.model.LogicalModel(mtype="ising")
     x = model.variables("x", shape=(4,))
@@ -229,13 +213,11 @@ def n_hot_from_scratch_4_of_1_ising():
     model.add_interaction(x[3], coefficient=-coeff)
     _print_utf8(model)
 
-    physical = model.to_physical()
-    solver = sawatabi.solver.LocalSolver(exact=True)
-    resultset = solver.solve(physical)
+    resultset = solver.solve(model.to_physical())
     print(resultset)
 
 
-def n_hot_from_scratch_4_of_2_ising():
+def n_hot_from_scratch_4_of_2_ising(solver):
     print("\n=== N-hot from scratch (4 of 1) ising ===")
     model = sawatabi.model.LogicalModel(mtype="ising")
     x = model.variables("x", shape=(4,))
@@ -255,24 +237,24 @@ def n_hot_from_scratch_4_of_2_ising():
     model.add_interaction(x[3], coefficient=-coeff)
     _print_utf8(model)
 
-    physical = model.to_physical()
-    solver = sawatabi.solver.LocalSolver(exact=True)
-    resultset = solver.solve(physical)
+    resultset = solver.solve(model.to_physical())
     print(resultset)
 
 
 def main():
-    n_hot_from_scratch_2_of_1_qubo()
-    n_hot_from_scratch_3_of_1_qubo()
-    n_hot_from_scratch_3_of_2_qubo()
-    n_hot_from_scratch_4_of_1_qubo()
-    n_hot_from_scratch_4_of_2_qubo()
+    solver = sawatabi.solver.LocalSolver(exact=True)
 
-    n_hot_from_scratch_2_of_1_ising()
-    n_hot_from_scratch_3_of_1_ising()
-    n_hot_from_scratch_3_of_2_ising()
-    n_hot_from_scratch_4_of_1_ising()
-    n_hot_from_scratch_4_of_2_ising()
+    n_hot_from_scratch_2_of_1_qubo(solver)
+    n_hot_from_scratch_3_of_1_qubo(solver)
+    n_hot_from_scratch_3_of_2_qubo(solver)
+    n_hot_from_scratch_4_of_1_qubo(solver)
+    n_hot_from_scratch_4_of_2_qubo(solver)
+
+    n_hot_from_scratch_2_of_1_ising(solver)
+    n_hot_from_scratch_3_of_1_ising(solver)
+    n_hot_from_scratch_3_of_2_ising(solver)
+    n_hot_from_scratch_4_of_1_ising(solver)
+    n_hot_from_scratch_4_of_2_ising(solver)
 
 
 if __name__ == "__main__":

--- a/sample/solver/dwave_solver.py
+++ b/sample/solver/dwave_solver.py
@@ -20,31 +20,30 @@ from _solver_helper import _create_ising_model, _print_resultset
 import sawatabi
 
 
-def solver_dwave():
+def solver_dwave(solver):
     print("\n=== solver (dwave) ===")
     physical = _create_ising_model()
 
-    solver = sawatabi.solver.DWaveSolver()
     resultset = solver.solve(physical, chain_strength=2.0, num_reads=10)
 
     _print_resultset(resultset)
 
 
-def solver_dwave_long_schedule():
+def solver_dwave_long_schedule(solver):
     print("\n=== solver (dwave long schedule) ===")
     physical = _create_ising_model()
 
-    solver = sawatabi.solver.DWaveSolver(solver="Advantage_system1.1")
-    resultset = solver.solve(
-        physical, embedding_parameters={"random_seed": 12345}, chain_strength=2.0, annealing_time=50, num_reads=1000, answer_mode="histogram"
-    )
+    resultset = solver.solve(physical, chain_strength=2.0, annealing_time=50, num_reads=1000, answer_mode="histogram")
 
     _print_resultset(resultset)
 
 
 def main():
-    solver_dwave()
-    solver_dwave_long_schedule()
+    # The solver will be reused
+    solver = sawatabi.solver.DWaveSolver(solver="Advantage_system1.1", embedding_parameters={"random_seed": 12345})
+
+    solver_dwave(solver)
+    solver_dwave_long_schedule(solver)
 
 
 if __name__ == "__main__":

--- a/sample/solver/local_solver.py
+++ b/sample/solver/local_solver.py
@@ -24,51 +24,49 @@ import sawatabi
 # fmt: on
 
 
-def solver_local_ising():
+def solver_local_ising(solver):
     print("\n=== solver (local ising) ===")
     physical = _create_ising_model()
 
-    solver = sawatabi.solver.LocalSolver(exact=False)
     resultset = solver.solve(physical, num_reads=1, num_sweeps=10000, seed=12345)
 
     _print_resultset(resultset)
 
 
-def solver_local_qubo():
+def solver_local_qubo(solver):
     print("\n=== solver (local qubo) ===")
     physical = _create_qubo_model()
 
-    solver = sawatabi.solver.LocalSolver(exact=False)
     resultset = solver.solve(physical, num_reads=1, num_sweeps=10000, seed=12345)
 
     _print_resultset(resultset)
 
 
-def solver_local_simple_2x2_ising_without_active_var():
+def solver_local_simple_2x2_ising_without_active_var(solver):
     print("\n=== solver (simple ising 2x2) ===")
     physical = _create_simple_2x2_ising_model_without_active_var()
 
-    solver = sawatabi.solver.LocalSolver(exact=False)
     resultset = solver.solve(physical, num_reads=1, num_sweeps=100, seed=12345)
 
     _print_resultset(resultset)
 
 
-def solver_local_simple_2x2_qubo_without_active_var():
+def solver_local_simple_2x2_qubo_without_active_var(solver):
     print("\n=== solver (simple qubo 2x2) ===")
     physical = _create_simple_2x2_qubo_model_without_active_var()
 
-    solver = sawatabi.solver.LocalSolver(exact=False)
     resultset = solver.solve(physical, num_reads=1, num_sweeps=100, seed=12345)
 
     _print_resultset(resultset)
 
 
 def main():
-    solver_local_ising()
-    solver_local_qubo()
-    solver_local_simple_2x2_ising_without_active_var()
-    solver_local_simple_2x2_qubo_without_active_var()
+    solver = sawatabi.solver.LocalSolver(exact=False)
+
+    solver_local_ising(solver)
+    solver_local_qubo(solver)
+    solver_local_simple_2x2_ising_without_active_var(solver)
+    solver_local_simple_2x2_qubo_without_active_var(solver)
 
 
 if __name__ == "__main__":

--- a/sawatabi/solver/dwave_solver.py
+++ b/sawatabi/solver/dwave_solver.py
@@ -21,21 +21,15 @@ from sawatabi.solver.abstract_solver import AbstractSolver
 
 
 class DWaveSolver(AbstractSolver):
-    def __init__(self, endpoint=None, token=None, solver="Advantage_system1.1"):
+    def __init__(self, endpoint=None, token=None, solver="Advantage_system1.1", embedding_parameters=None):
         super().__init__()
         self._endpoint = endpoint
         self._token = token
         self._solver = solver
 
-    def solve(self, model, embedding_parameters=None, **kwargs):
-        self._check_argument_type("model", model, PhysicalModel)
+        self._composite = self._create_composite(embedding_parameters)
 
-        if len(model._raw_interactions[constants.INTERACTION_LINEAR]) == 0 and len(model._raw_interactions[constants.INTERACTION_QUADRATIC]) == 0:
-            raise ValueError("Model cannot be empty.")
-
-        # Converts to BQM (model representation for D-Wave)
-        bqm = model.to_bqm()
-
+    def _create_composite(self, embedding_parameters=None):
         if (self._endpoint is not None) and (self._token is not None):
             sampler = DWaveSampler(endpoint=self._endpoint, token=self._token, solver=self._solver)
         else:
@@ -46,6 +40,17 @@ class DWaveSolver(AbstractSolver):
         else:
             solver = EmbeddingComposite(sampler)
 
-        sampleset = solver.sample(bqm, **kwargs)
+        return solver
+
+    def solve(self, model, **kwargs):
+        self._check_argument_type("model", model, PhysicalModel)
+
+        if len(model._raw_interactions[constants.INTERACTION_LINEAR]) == 0 and len(model._raw_interactions[constants.INTERACTION_QUADRATIC]) == 0:
+            raise ValueError("Model cannot be empty.")
+
+        # Converts to BQM (model representation for D-Wave)
+        bqm = model.to_bqm()
+
+        sampleset = self._composite.sample(bqm, **kwargs)
 
         return sampleset

--- a/sawatabi/solver/local_solver.py
+++ b/sawatabi/solver/local_solver.py
@@ -42,7 +42,7 @@ class LocalSolver(AbstractSolver):
 
         bqm = model.to_bqm()
 
-        start_time = time.time()
+        start_sec = time.perf_counter()
         if self._exact:
             # dimod's brute force solver
             sampleset = self._solver.sample(bqm)
@@ -51,9 +51,9 @@ class LocalSolver(AbstractSolver):
             sampleset = self._solver.sample(bqm, **kwargs)
 
         # Update the timing
-        elapsed_sec = time.time() - start_time
+        execution_sec = time.perf_counter() - start_sec
         sampleset.info["timing"] = {
-            "elapsed_sec": elapsed_sec,
+            "execution_sec": execution_sec,
         }
 
         return sampleset

--- a/sawatabi/solver/local_solver.py
+++ b/sawatabi/solver/local_solver.py
@@ -24,8 +24,15 @@ from sawatabi.solver.abstract_solver import AbstractSolver
 
 class LocalSolver(AbstractSolver):
     def __init__(self, exact=False):
-        self._exact = exact
         super().__init__()
+        self._exact = exact
+
+        if self._exact:
+            # dimod's brute force solver
+            self._solver = dimod.ExactSolver()
+        else:
+            # Simulated annealing (SA)
+            self._solver = neal.SimulatedAnnealingSampler()
 
     def solve(self, model, **kwargs):
         self._check_argument_type("model", model, PhysicalModel)
@@ -36,23 +43,17 @@ class LocalSolver(AbstractSolver):
         bqm = model.to_bqm()
 
         start_time = time.time()
-        start_counter = time.perf_counter()
-
         if self._exact:
             # dimod's brute force solver
-            sampleset = dimod.ExactSolver().sample(bqm)
-
+            sampleset = self._solver.sample(bqm)
         else:
             # Simulated annealing (SA)
-            sampler = neal.SimulatedAnnealingSampler()
-            sampleset = sampler.sample(bqm, **kwargs)
+            sampleset = self._solver.sample(bqm, **kwargs)
 
         # Update the timing
         elapsed_sec = time.time() - start_time
-        elapsed_counter = time.perf_counter() - start_counter
         sampleset.info["timing"] = {
             "elapsed_sec": elapsed_sec,
-            "elapsed_counter": elapsed_counter,
         }
 
         return sampleset

--- a/sawatabi/solver/optigan_solver.py
+++ b/sawatabi/solver/optigan_solver.py
@@ -91,7 +91,7 @@ class OptiganSolver(AbstractSolver):
             headers["Content-Encoding"] = "gzip"
             response = requests.post(endpoint, headers=headers, data=buf.getvalue())
         else:
-            # Don't comress request body
+            # Don't compress request body
             headers["Content-Type"] = "application/json; charset=UTF-8"
             response = requests.post(endpoint, headers=headers, json=payload)
 

--- a/sawatabi/solver/sawatabi_solver.py
+++ b/sawatabi/solver/sawatabi_solver.py
@@ -72,8 +72,7 @@ class SawatabiSolver(AbstractSolver):
         self._bqm = bqm
         self._rng = rng
 
-        start_time = time.time()
-        start_counter = time.perf_counter()
+        start_sec = time.perf_counter()
 
         samples = []
         energies = []
@@ -95,14 +94,12 @@ class SawatabiSolver(AbstractSolver):
             energies.append(energy)
 
         # Update the timing
-        elapsed_sec = time.time() - start_time
-        elapsed_counter = time.perf_counter() - start_counter
+        execution_sec = time.perf_counter() - start_sec
 
         sampleset = dimod.SampleSet.from_samples(samples, vartype=dimod.SPIN, energy=energies, aggregate_samples=True, sort_labels=True)
         sampleset._info = {
             "timing": {
-                "elapsed_sec": elapsed_sec,
-                "elapsed_counter": elapsed_counter,
+                "execution_sec": execution_sec,
             },
         }
 

--- a/sawatabi/utils/profile.py
+++ b/sawatabi/utils/profile.py
@@ -19,20 +19,17 @@ from functools import wraps
 def profile(func):
     @wraps(func)
     def profile_time(*args, **kargs):
-        start_time = time.time()
-        start_counter = time.perf_counter()
+        start_sec = time.perf_counter()
 
         func_return = func(*args, **kargs)
 
-        elapsed_sec = time.time() - start_time
-        elapsed_counter = time.perf_counter() - start_counter
+        execution_sec = time.perf_counter() - start_sec
 
         return {
             "return": func_return,
             "profile": {
                 "function_name": func.__name__,
-                "elapsed_sec": elapsed_sec,
-                "elapsed_counter": elapsed_counter,
+                "execution_sec": execution_sec,
             },
         }
 

--- a/tests/solver/test_dwave_solver.py
+++ b/tests/solver/test_dwave_solver.py
@@ -31,17 +31,15 @@ def physical():
 
 
 def test_dwave_solver(mocker, physical):
-    solver = DWaveSolver(solver="Advantage_system1.1")
-
     sampleset = dimod.SampleSet.from_samples([{"x[0]": 1, "x[1]": -1}], dimod.SPIN, energy=[-2.0])
     sampleset._info = {
         "timing": {"qpu_sampling_time": 12345},
         "problem_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     }
-
-    mocker.patch("dwave.system.samplers.DWaveSampler.__init__", return_value=None)
-    mocker.patch("dwave.system.composites.EmbeddingComposite.__init__", return_value=None)
     mocker.patch("dwave.system.composites.EmbeddingComposite.sample", return_value=sampleset)
+
+    solver = DWaveSolver(solver="Advantage_system1.1")
+
     resultset = solver.solve(physical)
 
     assert isinstance(resultset, dimod.SampleSet)
@@ -64,35 +62,33 @@ def test_dwave_solver(mocker, physical):
 
 
 def test_dwave_solver_with_auth_parameters(mocker, physical):
-    solver = DWaveSolver(endpoint="http://0.0.0.0/method", token="xxxx", solver="Advantage_system1.1")
-
     sampleset = dimod.SampleSet.from_samples([{"x[0]": 1, "x[1]": -1}], dimod.SPIN, energy=[-2.0])
     sampleset._info = {
         "timing": {"qpu_sampling_time": 12345},
         "problem_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     }
-
     mocker.patch("dwave.system.samplers.DWaveSampler.__init__", return_value=None)
     mocker.patch("dwave.system.composites.EmbeddingComposite.__init__", return_value=None)
     mocker.patch("dwave.system.composites.EmbeddingComposite.sample", return_value=sampleset)
+
+    solver = DWaveSolver(endpoint="http://0.0.0.0/method", token="xxxx", solver="Advantage_system1.1")
+
     resultset = solver.solve(physical)
 
     assert isinstance(resultset, dimod.SampleSet)
 
 
 def test_dwave_solver_with_embedding_parameters(mocker, physical):
-    solver = DWaveSolver(endpoint="http://0.0.0.0/method")
-
     sampleset = dimod.SampleSet.from_samples([{"x[0]": 1, "x[1]": -1}], dimod.SPIN, energy=[-2.0])
     sampleset._info = {
         "timing": {"qpu_sampling_time": 12345},
         "problem_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     }
-
-    mocker.patch("dwave.system.samplers.DWaveSampler.__init__", return_value=None)
-    mocker.patch("dwave.system.composites.EmbeddingComposite.__init__", return_value=None)
     mocker.patch("dwave.system.composites.EmbeddingComposite.sample", return_value=sampleset)
-    resultset = solver.solve(physical, embedding_parameters={"random_seed": 12345})
+
+    solver = DWaveSolver(endpoint="http://0.0.0.0/method", embedding_parameters={"random_seed": 12345})
+
+    resultset = solver.solve(physical)
 
     assert isinstance(resultset, dimod.SampleSet)
 
@@ -111,7 +107,6 @@ def test_dwave_solver_with_logical_model_fails():
 
 def test_dwave_solver_with_empty_model_fails():
     model = LogicalModel(mtype="ising")
-    physical = model.to_physical()
     solver = DWaveSolver()
     with pytest.raises(ValueError):
-        solver.solve(physical)
+        solver.solve(model.to_physical())

--- a/tests/solver/test_local_solver.py
+++ b/tests/solver/test_local_solver.py
@@ -83,6 +83,17 @@ def test_local_solver_sa_ising():
     assert resultset.record[0].energy == 6.0
     assert resultset.record[0].num_occurrences == 1
 
+    # Check the second solve with the same solver instance
+    resultset2 = solver.solve(model.to_physical(), seed=54321)
+
+    assert resultset2.variables == ["s[0]", "s[1]"]
+    assert len(resultset2.record) == 1
+
+    # Check the ground state
+    assert np.array_equal(resultset2.record[0].sample, [-1, 1])
+    assert resultset2.record[0].energy == 6.0
+    assert resultset2.record[0].num_occurrences == 1
+
 
 def test_local_solver_sa_qubo():
     model = LogicalModel(mtype="qubo")

--- a/tests/solver/test_local_solver.py
+++ b/tests/solver/test_local_solver.py
@@ -172,9 +172,8 @@ def test_local_solver_n_hot_ising(n, s):
         assert np.count_nonzero(result == 1) == n
         assert np.count_nonzero(result == -1) == s - n
 
-        # Execution time should be within practical seconds (10 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
+        # Execution time should be within practical seconds (20 sec).
+        assert resultset.info["timing"]["execution_sec"] <= 20.0
 
 
 @pytest.mark.parametrize("n,s", [(1, 2), (1, 3), (2, 3), (1, 4), (2, 4), (1, 100), (10, 100)])
@@ -193,9 +192,8 @@ def test_local_solver_n_hot_qubo(n, s):
         assert np.count_nonzero(result == 1) == n
         assert np.count_nonzero(result == 0) == s - n
 
-        # Execution time should be within practical seconds (10 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
+        # Execution time should be within practical seconds (20 sec).
+        assert resultset.info["timing"]["execution_sec"] <= 20.0
 
 
 @pytest.mark.parametrize("n,s,i", [(1, 4, 0), (1, 4, 1), (1, 4, 2), (1, 4, 3), (2, 10, 5)])
@@ -215,9 +213,8 @@ def test_local_solver_n_hot_ising_with_deleting(n, s, i):
         assert np.count_nonzero(result == 1) == n
         assert np.count_nonzero(result == -1) == s - n - 1
 
-        # Execution time should be within practical seconds (10 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
+        # Execution time should be within practical seconds (20 sec).
+        assert resultset.info["timing"]["execution_sec"] <= 10.0
 
 
 @pytest.mark.parametrize("n,s,i,j", [(1, 4, 0, 1), (1, 4, 2, 3), (2, 10, 5, 8)])
@@ -238,9 +235,8 @@ def test_local_solver_n_hot_qubo_with_deleting(n, s, i, j):
         assert np.count_nonzero(result == 1) == n
         assert np.count_nonzero(result == 0) == s - n - 2
 
-        # Execution time should be within practical seconds (10 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
+        # Execution time should be within practical seconds (20 sec).
+        assert resultset.info["timing"]["execution_sec"] <= 20.0
 
 
 ################################
@@ -265,9 +261,8 @@ def test_local_solver_equality_ising(m, n):
         result_2 = result[m : (m + n)]  # noqa: E203
         assert np.count_nonzero(result_1 == 1) == np.count_nonzero(result_2 == 1)
 
-        # Execution time should be within practical seconds (10 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
+        # Execution time should be within practical seconds (20 sec).
+        assert resultset.info["timing"]["execution_sec"] <= 20.0
 
 
 @pytest.mark.parametrize("m,n", [(2, 2), (10, 10), (10, 20), (50, 50)])
@@ -287,9 +282,8 @@ def test_local_solver_equality_qubo(m, n):
         result_2 = result[m : (m + n)]  # noqa: E203
         assert np.count_nonzero(result_1 == 1) == np.count_nonzero(result_2 == 1)
 
-        # Execution time should be within practical seconds (10 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
+        # Execution time should be within practical seconds (20 sec).
+        assert resultset.info["timing"]["execution_sec"] <= 20.0
 
 
 ################################
@@ -311,9 +305,8 @@ def test_local_solver_zero_or_one_hot_ising(n):
         result = np.array(resultset.record[0].sample)
         assert np.count_nonzero(result == 1) in [0, 1]
 
-        # Execution time should be within practical seconds (10 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
+        # Execution time should be within practical seconds (20 sec).
+        assert resultset.info["timing"]["execution_sec"] <= 20.0
 
 
 @pytest.mark.parametrize("n", [2, 3, 4, 10, 100])
@@ -330,6 +323,5 @@ def test_local_solver_zero_or_one_hot_qubo(n):
         result = np.array(resultset.record[0].sample)
         assert np.count_nonzero(result == 1) in [0, 1]
 
-        # Execution time should be within practical seconds (10 sec).
-        assert resultset.info["timing"]["elapsed_sec"] <= 10.0
-        assert resultset.info["timing"]["elapsed_counter"] <= 10.0
+        # Execution time should be within practical seconds (20 sec).
+        assert resultset.info["timing"]["execution_sec"] <= 20.0

--- a/tests/solver/test_sawatabi_solver.py
+++ b/tests/solver/test_sawatabi_solver.py
@@ -74,9 +74,8 @@ def test_sawatabi_solver_n_hot_ising(n, s):
     assert np.count_nonzero(result == 1) == n
     assert np.count_nonzero(result == -1) == s - n
 
-    # Execution time should be within practical seconds (10 sec).
-    assert resultset.info["timing"]["elapsed_sec"] <= 10.0
-    assert resultset.info["timing"]["elapsed_counter"] <= 10.0
+    # Execution time should be within practical seconds (20 sec).
+    assert resultset.info["timing"]["execution_sec"] <= 20.0
 
 
 @pytest.mark.parametrize("n,s", [(1, 2), (1, 3), (2, 3), (1, 4), (2, 4), (1, 100), (10, 100)])
@@ -93,9 +92,8 @@ def test_sawatabi_solver_n_hot_qubo(n, s):
     assert np.count_nonzero(result == 1) == n
     assert np.count_nonzero(result == 0) == s - n
 
-    # Execution time should be within practical seconds (10 sec).
-    assert resultset.info["timing"]["elapsed_sec"] <= 10.0
-    assert resultset.info["timing"]["elapsed_counter"] <= 10.0
+    # Execution time should be within practical seconds (20 sec).
+    assert resultset.info["timing"]["execution_sec"] <= 20.0
 
 
 @pytest.mark.parametrize("n,s,i", [(1, 4, 0), (1, 4, 1), (1, 4, 2), (1, 4, 3), (2, 10, 5)])

--- a/tests/utils/test_profile.py
+++ b/tests/utils/test_profile.py
@@ -40,8 +40,8 @@ def _create_n_variable_random_complete_model(n=4, seed=None):
 def test_create_n_variable_random_complete_model(n):
     result = _create_n_variable_random_complete_model(n=n, seed=12345)
 
-    # Execution time should be within practical seconds (10 sec).
-    assert result["profile"]["elapsed_sec"] < 10.0
+    # Execution time should be within practical seconds (20 sec).
+    assert result["profile"]["execution_sec"] < 20.0
 
 
 @profile
@@ -66,5 +66,5 @@ def _create_nxn_random_lattice_model(n=4, seed=None):
 def test_create_nxn_random_lattice_model(n):
     result = _create_nxn_random_lattice_model(n=n, seed=12345)
 
-    # Execution time should be within practical seconds (10 sec).
-    assert result["profile"]["elapsed_sec"] < 10.0
+    # Execution time should be within practical seconds (20 sec).
+    assert result["profile"]["execution_sec"] < 20.0


### PR DESCRIPTION
Create D-Wave solver instance in the constructor instead of doing it in each solve method.

TODO: Change to reuse the solver instance in the algorithm layer. This will affect the algorithm interfaces, do it later.